### PR TITLE
NGINX Proxy to Apache

### DIFF
--- a/inc/plugins/google_seo/plugin.php
+++ b/inc/plugins/google_seo/plugin.php
@@ -1197,6 +1197,23 @@ function google_seo_plugin_apply($apply=false)
                 '}',
                 ),
             );
+        
+        // build_profile_link
+        $edits[] = array(
+            'search' => array('return "<a href=\\"{$mybb->settings[\'bburl\']}/".get_profile_link($uid)."\\"{$target}{$onclick}>{$username}</a>";'),
+            'before' => array(
+                'if(function_exists("google_seo_url_profile"))',
+                '{',
+                '    $link = google_seo_url_profile($uid);',
+                '',
+                '    if ($link)',
+                '    {',
+                '        return "<a href=\"{$link}\"{$target}{$onclick}>{$username}</a>";',
+                '    }',
+                '}',
+            ),
+        );
+
     }
 
     if($settings['google_seo_url_announcements'])

--- a/inc/plugins/google_seo/redirect.php
+++ b/inc/plugins/google_seo/redirect.php
@@ -74,6 +74,13 @@ function google_seo_redirect_hook()
         // Never touch posts.
         return;
     }
+    
+    $rewritten = $mybb->get_input('rewritten', MyBB::INPUT_INT);
+    if ($rewritten)
+    {
+        // The URLs were already rewritten by the front-end webserver
+        return;
+    }
 
     // Build the target URL we should be at:
     switch(THIS_SCRIPT)

--- a/inc/plugins/google_seo/url.php
+++ b/inc/plugins/google_seo/url.php
@@ -925,7 +925,7 @@ function google_seo_url_cache($type, $id)
     }
 
     // Return the cached entry for the originally requested type and id.
-    return $google_seo_url_cache[$type][$id];
+    return $settings['bburl'] . '/' . $google_seo_url_cache[$type][$id];
 }
 
 /*

--- a/rewrite-nginx-apache.txt
+++ b/rewrite-nginx-apache.txt
@@ -1,0 +1,48 @@
+A tutorial for getting rewrite rules (MyBB SEF style) work with nginx:
+
+    http://community.mybboard.net/thread-51764.html
+
+The same method can be applied for Google SEO rewrite rules, but you 
+have to create those rules manually. Google SEO can not detect that 
+you are not using Apache, and will only generate .htaccess rules.
+
+Here is an example of what nginx rules for Google SEO look like:
+
+  # Google SEO workaround for search.php highlights:
+  # Make this rule the first rewrite rule in your .htaccess!
+  rewrite ^/MyBB/([^&]*)&(.*)$ http://yoursite/MyBB/$1?$2 permanent;
+
+  # Google SEO Sitemap:
+  rewrite ^/MyBB/((?i)sitemap-([^./]+)\.xml)$ /MyBB/misc.php?google_seo_sitemap=$2 last;
+
+  # Google SEO URL Forums:
+  rewrite ^/MyBB/((?i)Forum-([^./]+))$ /MyBB/forumdisplay.php?google_seo_forum=$2 last;
+
+  # Google SEO URL Threads:
+  rewrite ^/MyBB/((?i)Thread-([^./]+))$ /MyBB/showthread.php?google_seo_thread=$2 last;
+
+  # Google SEO URL Announcements:
+  rewrite ^/MyBB/((?i)Announcement-([^./]+))$ /MyBB/announcements.php?google_seo_announcement=$2 last;
+
+  # Google SEO URL Users:
+  rewrite ^/MyBB/((?i)User-([^./]+))$ /MyBB/member.php?action=profile&google_seo_user=$2 last;
+
+  # Google SEO URL Calendars:
+  rewrite ^/MyBB/((?i)Calendar-([^./]+))$ /MyBB/calendar.php?google_seo_calendar=$2 last;
+
+  # Google SEO URL Events:
+  rewrite ^/MyBB/((?i)Event-([^./]+))$ /MyBB/calendar.php?action=event&google_seo_event=$2 last;
+  
+  # In the event the server is using both NGINX and Apache,
+  # the URLs should have `rewritten` set to `1`.
+  
+  # Sets rewritten so that when the rewritten URL is proxied to Apache,
+  # the plugin won't try to redirect the user (causing an infinite loop,
+  # by redirecting to the SEO url, which is rewritten by NGINX and proxied to
+  # Apache, then redirected, etc.)
+  if ($is_args) {
+      set $args "$args&rewritten=1";
+  }
+  
+  # Proxy pass below
+  proxy_pass http://127.0.0.1:8001$uri$is_args$args

--- a/rewrite-nginx.txt
+++ b/rewrite-nginx.txt
@@ -32,11 +32,4 @@ Here is an example of what nginx rules for Google SEO look like:
 
   # Google SEO URL Events:
   rewrite ^/MyBB/((?i)Event-([^./]+))$ /MyBB/calendar.php?action=event&google_seo_event=$2;
-  
-  # In the event the server is using both NGINX and Apache,
-  # the URLs should have `rewritten` set to `1`.
-  
-  # If you're just copying and pasting, uncomment the lines below
-  # if ($is_args) {
-  #     set $args "$args&rewritten=1";
-  # }
+

--- a/rewrite-nginx.txt
+++ b/rewrite-nginx.txt
@@ -32,3 +32,11 @@ Here is an example of what nginx rules for Google SEO look like:
 
   # Google SEO URL Events:
   rewrite ^/MyBB/((?i)Event-([^./]+))$ /MyBB/calendar.php?action=event&google_seo_event=$2;
+  
+  # In the event the server is using both NGINX and Apache,
+  # the URLs should have `rewritten` set to `1`.
+  
+  # If you're just copying and pasting, uncomment the lines below
+  # if ($is_args) {
+  #     set $args "$args&rewritten=1";
+  # }


### PR DESCRIPTION
Some forum administrators, example being myself, may be working on an NGINX front-end that proxies to an Apache back-end (NGINX serving static content, Apache serving dynamic content).

Doing rewrites in NGINX can be a pain with this plugin (assuming that NGINX is proxying to Apache, that is. Otherwise, it's solid), so I've dug around, done some edits to enable this to be much easier to setup for an NGINX & Apache setup.