### PR TITLE
Fix online user location when there is unicode in the URL

### DIFF
--- a/inc/plugins/google_seo/url.php
+++ b/inc/plugins/google_seo/url.php
@@ -1109,8 +1109,8 @@ function google_seo_url_hook()
                 $fid = google_seo_url_id(GOOGLE_SEO_FORUM, $url);
                 $mybb->input['fid'] = $fid;
                 $location = get_current_location();
-                $location = str_replace("google_seo_forum={$url}",
-                                        "fid={$fid}", $location);
+                $start = strpos($location, "google_seo_forum=");
+                $location = substr_replace($location, "fid={$fid}", $start);
             }
 
             // Verification.
@@ -1132,8 +1132,8 @@ function google_seo_url_hook()
                 $tid = google_seo_url_id(GOOGLE_SEO_THREAD, $url);
                 $mybb->input['tid'] = $tid;
                 $location = get_current_location();
-                $location = str_replace("google_seo_thread={$url}",
-                                        "tid={$tid}", $location);
+                $start = strpos($location, "google_seo_thread=");
+                $location = substr_replace($location, "tid={$tid}", $start);
             }
 
             // Verification.
@@ -1157,7 +1157,8 @@ function google_seo_url_hook()
                 $aid = google_seo_url_id(GOOGLE_SEO_ANNOUNCEMENT, $url);
                 $mybb->input['aid'] = $aid;
                 $location = get_current_location();
-                $location = str_replace("google_seo_announcement={$url}", "aid={$aid}", $location);
+                $start = strpos($location, "google_seo_announcement=");
+                $location = substr_replace($location, "aid={$aid}", $start);
             }
 
             // Verification.


### PR DESCRIPTION
The location of some online users is not shown correctly if the URL of the location has unicode characters. It is shown only as viewing a thread or a forum without specifying which thread or forum.
Each UTF-8 character in the URL is converted to a few ascii letters which cause some PHP string search functionality including `str_replace` to fail.
This PR fixed the issue.